### PR TITLE
Fix gossip Not showing up

### DIFF
--- a/src/SkipDK.cpp
+++ b/src/SkipDK.cpp
@@ -208,7 +208,7 @@ public:
         {
             int DKL = sConfigMgr->GetFloatDefault("Skip.Deathknight.Start.Level", 58);
             CloseGossipMenuFor(player);
-
+            ClearGossipMenuFor(player);
             switch (gossipListId)
             {
             case 11:


### PR DESCRIPTION
Reported in discord that the option gossip to skip was not showing up. this fixes it.