### PR TITLE
Fix compilation error regarding getLevel API change

### DIFF
--- a/conf/skip_dk_module.conf.dist
+++ b/conf/skip_dk_module.conf.dist
@@ -42,6 +42,14 @@ GM.Skip.Deathknight.Starter.Enable = 0
 Skip.Deathknight.Start.Level = 58
 
 #
+#    Skip.Deathknight.Start.Trained
+#         Automatically trains skills up to 58, as might be expected by the end of the start zone.
+#         Default: 0 - (Inactive)
+#
+
+Skip.Deathknight.Start.Trained = 1
+
+#
 #    Skip.Deathknight.Optional.Enable
 #    Enables optional to skip when talking to lich king on first creation of dk.
 #    Default: 1 - (Active)

--- a/src/SkipDK.cpp
+++ b/src/SkipDK.cpp
@@ -110,7 +110,7 @@ void Azerothcore_skip_deathknight_HandleSkip(Player* player)
     player->AddItem(38632, true);//Greatsword of the Ebon Blade
 
     int DKL = sConfigMgr->GetOption<float>("Skip.Deathknight.Start.Level", 58);
-    if (player->getLevel() <= DKL)
+    if (player->GetLevel() <= DKL)
     {
         //GiveLevel updates character properties more thoroughly than SetLevel
         player->GiveLevel(DKL);

--- a/src/SkipDK.cpp
+++ b/src/SkipDK.cpp
@@ -116,6 +116,19 @@ void Azerothcore_skip_deathknight_HandleSkip(Player* player)
         player->GiveLevel(DKL);
     }
 
+    if (sConfigMgr->GetOption<bool>("Skip.Deathknight.Start.Trained", false))
+    {
+        player->addSpell(49998, SPEC_MASK_ALL, true); // Death Strike rank 1
+        player->addSpell(47528, SPEC_MASK_ALL, true); // Mind Freeze
+        player->addSpell(46584, SPEC_MASK_ALL, true); // Raise Dead
+        player->addSpell(45524, SPEC_MASK_ALL, true); // Chains of Ice
+        player->addSpell(48263, SPEC_MASK_ALL, true); // Frost Presence
+        player->addSpell(50842, SPEC_MASK_ALL, true); // Pestilence
+        player->addSpell(53342, SPEC_MASK_ALL, true); // Rune of Spellshattering
+        player->addSpell(48721, SPEC_MASK_ALL, true); // Blood Boil rank 1
+        player->addSpell(54447, SPEC_MASK_ALL, true); // Rune of Spellbreaking
+    }
+
     //Don't need to save all players, just current
     player->SaveToDB(false, false);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Changes getLevel to GetLevel - simple API update

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #21 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
(Not sure what I'm supposed to put here - source of what?)

## Tests Performed:

Builds, seems to work correctly (though I note an unrelated issue, wherein using the non-optional configuration mode conflicts with the opening cinematic unpleasantly).

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a DK
2. Log into the DK
3. If optional skip is configured, talk to the Lich King and ask to skip the starting quests.

One should find themselves with a level 58 DK in their faction city and an inventory full of quest rewards.
