### PR TITLE
Adds an option to automatically train the skills that might be expect…

### DIFF
--- a/conf/skip_dk_module.conf.dist
+++ b/conf/skip_dk_module.conf.dist
@@ -42,6 +42,14 @@ GM.Skip.Deathknight.Starter.Enable = 0
 Skip.Deathknight.Start.Level = 58
 
 #
+#    Skip.Deathknight.Start.Trained
+#         Automatically trains skills up to 58, as might be expected by the end of the start zone.
+#         Default: 0 - (Inactive)
+#
+
+Skip.Deathknight.Start.Trained = 1
+
+#
 #    Skip.Deathknight.Optional.Enable
 #    Enables optional to skip when talking to lich king on first creation of dk.
 #    Default: 1 - (Active)

--- a/src/SkipDK.cpp
+++ b/src/SkipDK.cpp
@@ -116,6 +116,19 @@ void Azerothcore_skip_deathknight_HandleSkip(Player* player)
         player->GiveLevel(DKL);
     }
 
+    if (sConfigMgr->GetOption<bool>("Skip.Deathknight.Start.Trained", false))
+    {
+        player->addSpell(49998, SPEC_MASK_ALL, true); // Death Strike rank 1
+        player->addSpell(47528, SPEC_MASK_ALL, true); // Mind Freeze
+        player->addSpell(46584, SPEC_MASK_ALL, true); // Raise Dead
+        player->addSpell(45524, SPEC_MASK_ALL, true); // Chains of Ice
+        player->addSpell(48263, SPEC_MASK_ALL, true); // Frost Presence
+        player->addSpell(50842, SPEC_MASK_ALL, true); // Pestilence
+        player->addSpell(53342, SPEC_MASK_ALL, true); // Rune of Spellshattering
+        player->addSpell(48721, SPEC_MASK_ALL, true); // Blood Boil rank 1
+        player->addSpell(54447, SPEC_MASK_ALL, true); // Rune of Spellbreaking
+    }
+
     //Don't need to save all players, just current
     player->SaveToDB(false, false);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Automatically trains the skills that might be expected (or at least are options to have) by the end of the training zone. This saves the player an immediate run back to the trainer.

NOTE: As a rookie to AzerothCore, I'm not sure if there's a simple way to instead say "train all spells up to current level". That might be preferable to my current approach of adding a fixed list of the spells up to level 58.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

NA, feature addition.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Builds cleanly on Rocky 8
- Expected additions to the character are made during skip according to the config option.
- Playing on AzerothCore rev. 8cfb3383287b+ 2024-07-31 09:10:12 +0200 (master branch) 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Set the new option `Skip.Deathknight.Start.Trained = 1`
2. Create a new DK
3. Observe that the expected spells are trained.
4. Use Death Gate to travel back to a trainer and observe that no further training is available. 
