### PR TITLE
Fix compilation error regarding getLevel API change

### DIFF
--- a/src/SkipDK.cpp
+++ b/src/SkipDK.cpp
@@ -110,7 +110,7 @@ void Azerothcore_skip_deathknight_HandleSkip(Player* player)
     player->AddItem(38632, true);//Greatsword of the Ebon Blade
 
     int DKL = sConfigMgr->GetOption<float>("Skip.Deathknight.Start.Level", 58);
-    if (player->getLevel() <= DKL)
+    if (player->GetLevel() <= DKL)
     {
         //GiveLevel updates character properties more thoroughly than SetLevel
         player->GiveLevel(DKL);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Changes getLevel to GetLevel - simple API update

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #21 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
(Not sure what I'm supposed to put here - source of what?)

## Tests Performed:

Builds on Rocky Linux 8 with AzerothCore rev. 8cfb3383287b+ 2024-07-31 09:10:12 +0200 (master branch) .

Seems to work correctly (though I note an unrelated issue, wherein using the non-optional-skip configuration modes conflicts with the opening cinematic unpleasantly).

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a DK
2. Log into the DK
3. If optional skip is configured, talk to the Lich King and ask to skip the starting quests.

One should find themselves with a level 58 DK in their faction city and an inventory full of quest rewards.
