### PR TITLE
Fix Optional

### DIFF
--- a/src/SkipDK.cpp
+++ b/src/SkipDK.cpp
@@ -180,7 +180,10 @@ public:
             if ((sConfigMgr->GetOption<bool>("Skip.Deathknight.Starter.Enable", true) && player->GetSession()->GetSecurity() == SEC_PLAYER)
                 || (sConfigMgr->GetOption<bool>("GM.Skip.Deathknight.Starter.Enable", true) && player->GetSession()->GetSecurity() >= SEC_MODERATOR))
             {
-                Azerothcore_skip_deathknight_HandleSkip(player);
+                if (!sConfigMgr->GetOption<bool>("Skip.Deathknight.Optional.Enable", false))
+                {
+                    Azerothcore_skip_deathknight_HandleSkip(player);
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Now if 'Skip.Deathknight.Optional.Enable' is set to 1, you don't get instant teleported to Stormwind/Orgrimmar on first login.
- This fixes an annoying bug that, after being teleported, your character name is Unknown and you have to relog to fix it.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-skip-dk-starting-area/issues/20

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in-game
- 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.  Set Skip.Deathknight.Optional.Enable to 1 and create a DK
2. Observe that now you can optional skip the DK starting zone. Without this you will always be teleported to Stormwind/Orgrimmar, the 'Skip.Deathknight.Optional.Enable' just didn't work.