### PR TITLE
feat: apply weapon enchantment

### DIFF
--- a/conf/skip_dk_module.conf.dist
+++ b/conf/skip_dk_module.conf.dist
@@ -5,19 +5,19 @@
 #        Enable this if you want to skip the Deathknight starting area
 #        Start with level 58 DK with Runeforging.
 #
-#    Skip.Deathknight.Starter.Announce.enable
+#    Skip.Deathknight.Starter.Announce.Enable
 #         Description: Announces Module when player logs in.
-#         Default:    0 - (Disabled)
-#                     1 - (Enabled)
+#         Default:    1 - (Enabled)
+#                     0 - (Disabled)
 #
 
-Skip.Deathknight.Starter.Announce.enable = 1
+Skip.Deathknight.Starter.Announce.Enable = 1
 
 #
 #    Skip.DeathKnight.Starter.Enable
 #         Active Module for all new accounts regardless of account level. Instant Skip on DK Creation.
-#         Default:    0 - (Disabled)
-#                     1 - (Enabled)
+#         Default:    1 - (Enabled)
+#                     0 - (Disabled)
 #
 
 Skip.Deathknight.Starter.Enable = 1
@@ -25,9 +25,8 @@ Skip.Deathknight.Starter.Enable = 1
 #
 #    GM.Skip.Deathknight.Starter.Enable
 #         Active Module for all new accounts of a GM account level ONLY. Instant Skip on DK Creation.
-#         Ensure you have Skip.Deathknight.Starter.Enable set to 0 if using this conf.
 #         Default:    0 - (Disabled)
-#                     1 - (Enabled)
+#                     1 - (Enabled) Skip.DeathKnight.Starter.Enable must be 0
 #
 
 GM.Skip.Deathknight.Starter.Enable = 0
@@ -44,23 +43,26 @@ Skip.Deathknight.Start.Level = 58
 #
 #    Skip.Deathknight.Start.Trained
 #         Automatically trains skills up to 58, as might be expected by the end of the start zone.
-#         Default: 0 - (Inactive)
+#         Default:    1 - (Enabled)
+#                     0 - (Disabled)
 #
 
 Skip.Deathknight.Start.Trained = 1
 
 #
 #    Skip.Deathknight.Optional.Enable
-#    Enables optional to skip when talking to lich king on first creation of dk.
-#    Default: 1 - (Active)
+#         Enables optional to skip when talking to lich king on first creation of dk.
+#         Default:    1 - (Enabled)
+#                     0 - (Disabled)
 #
 
 Skip.Deathknight.Optional.Enable = 1
 
 #
 #    DeleteGold.Deathknight.Optional.Enable
-#    Enables option to delete all gold reward from quests on skip of dk. To stop this as sort of exploitative gold income.
-#    Default: 1 - (Active)
+#         Enables option to delete all gold reward from quests on skip of dk. To stop this as sort of exploitative gold income.
+#         Default:    1 - (Enabled)
+#                     0 - (Disabled)
 #
 
 DeleteGold.Deathknight.Optional.Enable = 1

--- a/conf/skip_dk_module.conf.dist
+++ b/conf/skip_dk_module.conf.dist
@@ -66,3 +66,13 @@ Skip.Deathknight.Optional.Enable = 1
 #
 
 DeleteGold.Deathknight.Optional.Enable = 1
+
+#
+#   Skip.Deathknight.Start.WeaponEnchantment
+#         EnchantmentId to apply to starting DK 2H weapons. This value is the EffectMiscValueA of SPELL_EFFECT_ENCHANT_ITEM
+#         Default:    3369 - (Rune of Cinderglacier)
+#                     3370 - (Rune of Razorice)
+#                     0 - (Disabled)
+#
+
+Skip.Deathknight.Start.WeaponEnchantment = 3369

--- a/src/SkipDK.cpp
+++ b/src/SkipDK.cpp
@@ -149,6 +149,21 @@ void Azerothcore_skip_deathknight_HandleSkip(Player* player)
         int DKM = sConfigMgr->GetOption<int32>("StartHeroicPlayerMoney", 2000);
         player->SetMoney(DKM);
     }
+
+    auto ApplyEnchantment = [&](uint32 enchantId, Item* item, Player* player)
+    {
+        // Session may be null, so write enchantment fields directly
+        uint32 base = ITEM_FIELD_ENCHANTMENT_1_1 + PERM_ENCHANTMENT_SLOT * MAX_ENCHANTMENT_OFFSET;
+        item->SetUInt32Value(base + ENCHANTMENT_ID_OFFSET, enchantId);
+        item->SetUInt32Value(base + ENCHANTMENT_DURATION_OFFSET, 0);
+        item->SetUInt32Value(base + ENCHANTMENT_CHARGES_OFFSET, 0);
+        item->SetState(ITEM_CHANGED, player);
+    };
+
+    if (uint32 enchantId = sConfigMgr->GetOption<uint32>("Skip.Deathknight.Start.WeaponEnchantment", 3369)) // Rune of Cinderglacier
+        for (uint32 itemId : {38632, 38633, 38707}) // Greatsword/Greataxe of the Ebon Blade, Runed Soulblade
+            if (Item* item = player->GetItemByEntry(itemId))
+                ApplyEnchantment(enchantId, item, player);
 }
 
 class AzerothCore_skip_deathknight_announce : public PlayerScript

--- a/src/SkipDK.cpp
+++ b/src/SkipDK.cpp
@@ -114,7 +114,7 @@ void Azerothcore_skip_deathknight_HandleSkip(Player* player)
         player->GiveLevel(DKL);
     }
 
-    if (sConfigMgr->GetOption<bool>("Skip.Deathknight.Start.Trained", false))
+    if (sConfigMgr->GetOption<bool>("Skip.Deathknight.Start.Trained", true))
     {
         player->addSpell(49998, SPEC_MASK_ALL, true); // Death Strike rank 1
         player->addSpell(47528, SPEC_MASK_ALL, true); // Mind Freeze
@@ -160,7 +160,7 @@ public:
 
     void OnPlayerLogin(Player* Player)
     {
-        if (sConfigMgr->GetOption<bool>("Skip.Deathknight.Starter.Announce.enable", true) && (sConfigMgr->GetOption<bool>("Skip.Deathknight.Starter.Enable", true) || sConfigMgr->GetOption<bool>("Skip.Deathknight.Optional.Enable", true)))
+        if (sConfigMgr->GetOption<bool>("Skip.Deathknight.Starter.Announce.Enable", true) && (sConfigMgr->GetOption<bool>("Skip.Deathknight.Starter.Enable", true) || sConfigMgr->GetOption<bool>("Skip.Deathknight.Optional.Enable", true)))
             ChatHandler(Player->GetSession()).SendSysMessage("This server is running the |cff4CFF00Azerothcore Skip Deathknight Starter |rmodule.");
     }
 };
@@ -178,7 +178,7 @@ public:
         {
             //These changes make it so user mistakes in the configuration file don't cause this to run 2x
             if ((sConfigMgr->GetOption<bool>("Skip.Deathknight.Starter.Enable", true) && player->GetSession()->GetSecurity() == SEC_PLAYER)
-                || (sConfigMgr->GetOption<bool>("GM.Skip.Deathknight.Starter.Enable", true) && player->GetSession()->GetSecurity() >= SEC_MODERATOR))
+                || (sConfigMgr->GetOption<bool>("GM.Skip.Deathknight.Starter.Enable", false) && player->GetSession()->GetSecurity() >= SEC_MODERATOR))
             {
                 Azerothcore_skip_deathknight_HandleSkip(player);
             }


### PR DESCRIPTION
[[edited copilot summary]]

requires:
- https://github.com/azerothcore/mod-skip-dk-starting-area/pull/29

Add support for automatically enchanting starting DK weapons for GM accounts.

**New feature: weapon enchantment**

* Added a new configuration option `Skip.Deathknight.Starter.WeaponEnchantment` to allow specifying an enchantment for starting DK weapons. Implemented logic to apply the enchantment to relevant items when skipping the DK starter area. 

## Changes Proposed:
- 
- 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- ✅
- 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
